### PR TITLE
Fixed bug where multiple items were able to be dragged together

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://scenes/game.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 
+[autoload]
+
+gameGlobals="*res://scripts/game_globals.gd"
+
 [display]
 
 window/size/viewport_width=1280

--- a/scripts/food_bowl.gd
+++ b/scripts/food_bowl.gd
@@ -13,14 +13,19 @@ func _physics_process(_delta) -> void:
 	if draggable:
 		if Input.is_action_just_pressed("action"):
 			sprite_offset = get_global_mouse_position() - self.position
+			gameGlobals.can_drag_item = false
 			
 		if Input.is_action_pressed("action"):
 			self.position = get_global_mouse_position() - sprite_offset
+		elif Input.is_action_just_released("action"):
+			gameGlobals.can_drag_item = true
 
 func _on_area_2d_mouse_entered():
-	draggable = true
-	self.scale = SCALE_ON_HOVER
+	if gameGlobals.can_drag_item:
+		draggable = true
+		self.scale = SCALE_ON_HOVER
 
 func _on_area_2d_mouse_exited():
-	draggable = false
-	self.scale = scale_on_load
+	if gameGlobals.can_drag_item:
+		draggable = false
+		self.scale = scale_on_load

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -5,6 +5,7 @@ const FOOD_BOWL = preload("res://scenes/food_bowl.tscn")
 const WATER_BOWL_SCENE = preload("res://scenes/water_bowl.tscn")
 
 func _ready() -> void:
+	gameGlobals.can_drag_item = true
 	var dog_scene_instance = DOG.instantiate()
 	var food_bowl_scene_instance = FOOD_BOWL.instantiate()
 	var water_bowl_scene_instance = WATER_BOWL_SCENE.instantiate()

--- a/scripts/game_globals.gd
+++ b/scripts/game_globals.gd
@@ -1,0 +1,3 @@
+extends Node2D
+
+var can_drag_item : bool = true

--- a/scripts/water_bowl.gd
+++ b/scripts/water_bowl.gd
@@ -13,14 +13,19 @@ func _physics_process(_delta) -> void:
 	if draggable:
 		if Input.is_action_just_pressed("action"):
 			sprite_offset = get_global_mouse_position() - self.position
+			gameGlobals.can_drag_item = false
 			
 		if Input.is_action_pressed("action"):
 			self.position = get_global_mouse_position() - sprite_offset
-
+		elif Input.is_action_just_released("action"):
+			gameGlobals.can_drag_item = true
+			
 func _on_area_2d_mouse_entered():
-	draggable = true
-	self.scale = SCALE_ON_HOVER
+	if gameGlobals.can_drag_item:
+		draggable = true
+		self.scale = SCALE_ON_HOVER
 
 func _on_area_2d_mouse_exited():
-	draggable = false
-	self.scale = scale_on_load
+	if gameGlobals.can_drag_item:
+		draggable = false
+		self.scale = scale_on_load


### PR DESCRIPTION
Added:

- `game_gloabls.gd` script referenced via `gameGlobals`.
- This script has a boolean var, `can_drag_item`. When the var is false, it means we're already dragging an item so it shouldn't allow another item to get stuck and be dragged along.