### PR TITLE
Feature/increase patience at fixed rate

### DIFF
--- a/scripts/dog.gd
+++ b/scripts/dog.gd
@@ -183,10 +183,12 @@ func handle_patience_loss():
 # Check if current status has been cured correctly
 func check_is_status_cured(delta: float):
 	if target_cure_status == current_status and current_status != "":
-		patience += patience_increment_rate * delta
-		if patience >= MAX_PATIENCE:
-			patience = MAX_PATIENCE
-		is_curing_status = true
+		# Increase patience if correct item placed and dropped
+		if gameGlobals.can_drag_item:
+			patience += patience_increment_rate * delta
+			if patience >= MAX_PATIENCE:
+				patience = MAX_PATIENCE
+			is_curing_status = true
 	elif current_status != "":
 		patience -= patience_reduction_rate * delta
 

--- a/scripts/dog.gd
+++ b/scripts/dog.gd
@@ -66,7 +66,7 @@ func _physics_process(delta):
 			status_icon.show_icon(current_status)
 			print(current_status)
 
-	if not is_moving:
+	if not is_moving and not is_curing_status:
 		move_time_accumulator += delta
 		if move_time_accumulator >= move_interval:
 			set_random_position()
@@ -93,6 +93,11 @@ func _physics_process(delta):
 
 	# Update animation based on direction
 	var direction = (target_position - position).normalized()
+
+	# Stop moving when curing status
+	if is_curing_status:
+		is_moving = false
+
 	if is_moving:
 		move_to_target(direction)
 	update_animation(is_moving, direction)


### PR DESCRIPTION
Made the following changes
- Increase patience at fixed rate when item is in action area
- Clear status if item removed from area, and correct item is used
- Stop moving if attempting to cure status and generate new position afterwards
- Reduce patience faster if wrong item is placed